### PR TITLE
Handle macOS artifact name changes

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -37,7 +37,25 @@ download_release() {
   if [[ "$OSTYPE" == "linux-gnu"* ]]; then
     bin="linux"
   elif [[ "$OSTYPE" == "darwin"* ]]; then
-    bin="osx"
+    # spago release artifacts have changed names over time for macOS.
+    #
+    # - "osx.tar.gz" up to and including 0.17.0 (other than a few exceptions)
+    # - "macOS-latest.tar.gz" for 0.18.0
+    # - "macOS.tar.gz" for 0.18.1 onwards (up to 0.19.0 as of this writing)
+    #
+    # There are a few other outlier versions which might not be handled here, and the very
+    # early versions don't seem to contain an executable named "spago" so those don't work either.
+    #
+    # See https://github.com/purescript/spago/releases for release artifact filenames
+    major_version=$(echo $version | cut -d'.' -f1)
+    minor_version=$(echo $version | cut -d'.' -f2)
+    if [[ "$version" == "0.18.0" ]]; then
+      bin="macOS-latest"
+    elif (( $major_version == 0 && $minor_version < 18 )); then
+      bin="osx"
+    else
+      bin="macOS"
+    fi
   else
     fail "unrecognized operating system $OSTYPE"
   fi


### PR DESCRIPTION
I was playing around with `asdf` for installing the `purescript` `0.14.0` release candidates tonight, and I noticed the `asdf-spago` install wasn't working for spago `0.19.0`. The reason is that the macOS artifact changed names from `osx.tar.gz` to `macOS.tar.gz`. I tried to patch the bash script in kind of a simple/hacky way to make it work for at least the last 5 or so versions of `spago`.

I tested `asdf install spago 0.16.0` and all versions up to the latest `0.19.0`. Before `0.16.0` the artifact names didn't seem to be consistent and/or the contents of the .tar.gz files did not contain the expected files, but I figured nobody would probably be trying to use those older versions at this point. The `macOS.tar.gz` name will be treated as the default going forward, so only the older names are special-cased.